### PR TITLE
Handle changed date attributes which are not formatted as date strings

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,14 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
-         backupStaticAttributes="false"
          bootstrap="vendor/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="true"
 >
 
     <testsuites>
@@ -16,12 +11,6 @@
             <directory suffix="Test.php">./tests/</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="false">
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
 
     <php>
         <env name="APP_ENV" value="testing"/>

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -134,7 +134,9 @@ trait RevisionableTrait
                     ) {
                         $carbonObject = $this->asDateTime($val);
                         
-                        $this->updatedData[$key] = $carbonObject->toDateString();
+                        $this->updatedData[$key] = $carbonObject
+                            ->timezone('UTC')
+                            ->toDateString();
                 }
 
                 $castCheck = ['object', 'array'];

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -129,22 +129,22 @@ trait RevisionableTrait
             foreach ($this->updatedData as $key => $val) {
                 // Handle changed attributes which are stored as date strings in the DB
                 if (
-                    $this->changedAttributeIsADate($key) &&
-                    $this->isStandardDateFormat($this->originalData[$key])
-                    ) {
-                        $carbonObject = $this->asDateTime($val);
-                        
-                        $this->updatedData[$key] = $carbonObject
-                            ->timezone('UTC')
-                            ->toDateString();
+                    $this->changedAttributeIsADate($key)
+                    && $this->isStandardDateFormat($this->originalData[$key])
+                ) {
+                    $carbonObject = $this->asDateTime($val);
+
+                    $this->updatedData[$key] = $carbonObject
+                        ->timezone('UTC')
+                        ->toDateString();
                 }
 
                 $castCheck = ['object', 'array'];
-                if (isset($this->casts[$key]) && 
-                    in_array(gettype($val), $castCheck) && 
-                    in_array($this->casts[$key], $castCheck) && 
-                    isset($this->originalData[$key])
-                    ) {
+                if (isset($this->casts[$key])
+                    && in_array(gettype($val), $castCheck)
+                    && in_array($this->casts[$key], $castCheck)
+                    && isset($this->originalData[$key])
+                ) {
                     // Sorts the keys of a JSON object due Normalization performed by MySQL
                     // So it doesn't set false flag if it is changed only order of key or whitespace after comma
 
@@ -557,14 +557,14 @@ trait RevisionableTrait
 
     private function changedAttributeIsADate(string $key): bool
     {
-       if (!isset($this->originalData[$key])) {
+        if (!isset($this->originalData[$key])) {
             return false;
         }
 
         $value = $this->updatedData[$key];
 
-        return  $value instanceof Carbon || 
-            $this->isDateAttribute($key) || 
-            $this->isDateCastableWithCustomFormat($key);
+        return  $value instanceof Carbon
+            || $this->isDateAttribute($key)
+            || $this->isDateCastableWithCustomFormat($key);
     }
 }

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -123,19 +123,21 @@ trait RevisionableTrait
     {
         if (!isset($this->revisionEnabled) || $this->revisionEnabled) {
             // if there's no revisionEnabled. Or if there is, if it's true
-
             $this->originalData = $this->original;
             $this->updatedData = $this->attributes;
 
             foreach ($this->updatedData as $key => $val) {
-
                 // Handle changed attributes which are stored as date strings in the DB
                 if (
                     $this->changedAttributeIsADate($key) &&
                     $this->isStandardDateFormat($this->originalData[$key])
                     ) {
-                        $dateObject = $this->asDateTime($val);
-                        $this->updatedData[$key] = $dateObject->toDateString();
+                        $carbonObject = $this->asDateTime($val);
+
+                        // Use the app timezone configuration to standardize date comparison
+                        $this->updatedData[$key] = $carbonObject
+                            ->setTimezone('UTC')
+                            ->toDateString();
                 }
 
                 $castCheck = ['object', 'array'];

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -133,11 +133,8 @@ trait RevisionableTrait
                     $this->isStandardDateFormat($this->originalData[$key])
                     ) {
                         $carbonObject = $this->asDateTime($val);
-
-                        // Use the app timezone configuration to standardize date comparison
-                        $this->updatedData[$key] = $carbonObject
-                            ->setTimezone('UTC')
-                            ->toDateString();
+                        
+                        $this->updatedData[$key] = $carbonObject->toDateString();
                 }
 
                 $castCheck = ['object', 'array'];

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -4,6 +4,7 @@ namespace Venturecraft\Revisionable;
 
 use App\Repositories\Revision\RevisionRepository;
 use Illuminate\Support\Arr;
+use Carbon\Carbon;
 
 /*
  * This file is part of the Revisionable package by Venture Craft
@@ -126,11 +127,23 @@ trait RevisionableTrait
             $this->originalData = $this->original;
             $this->updatedData = $this->attributes;
 
-            // we can only safely compare basic items,
-            // so for now we drop any object based items, like DateTime
             foreach ($this->updatedData as $key => $val) {
+
+                // Handle changed attributes which are stored as date strings in the DB
+                if (
+                    $this->changedAttributeIsADate($key) &&
+                    $this->isStandardDateFormat($this->originalData[$key])
+                    ) {
+                        $dateObject = $this->asDateTime($val);
+                        $this->updatedData[$key] = $dateObject->toDateString();
+                }
+
                 $castCheck = ['object', 'array'];
-                if (isset($this->casts[$key]) && in_array(gettype($val), $castCheck) && in_array($this->casts[$key], $castCheck) && isset($this->originalData[$key])) {
+                if (isset($this->casts[$key]) && 
+                    in_array(gettype($val), $castCheck) && 
+                    in_array($this->casts[$key], $castCheck) && 
+                    isset($this->originalData[$key])
+                    ) {
                     // Sorts the keys of a JSON object due Normalization performed by MySQL
                     // So it doesn't set false flag if it is changed only order of key or whitespace after comma
 
@@ -539,5 +552,18 @@ trait RevisionableTrait
         }
 
         return $attribute;
+    }
+
+    private function changedAttributeIsADate(string $key): bool
+    {
+       if (!isset($this->originalData[$key])) {
+            return false;
+        }
+
+        $value = $this->updatedData[$key];
+
+        return  $value instanceof Carbon || 
+            $this->isDateAttribute($key) || 
+            $this->isDateCastableWithCustomFormat($key);
     }
 }

--- a/tests/DateRevisionTest.php
+++ b/tests/DateRevisionTest.php
@@ -166,8 +166,40 @@ class DateRevisionTest extends TestCase
             'date' => 'date::Y-m-d',
         ]);
 
-        // Create a datetime string that represents the same date in a different timezone
+        // Create a datetime object that represents the same date in a different timezone
         $dateTimeInNonUtcTimezone = Carbon::parse('2025-03-31 20:00:00.0', 'America/New_York');
+
+        $user->update([
+            'date' => $dateTimeInNonUtcTimezone
+        ]);
+
+        // we should have no revisions to the date
+        $this->assertCount(0, $user->revisionHistory);
+    }
+
+
+    #[Test]
+    public function revision_is_not_stored_when_a_custom_cast_datetime_string_in_a_different_timezone_is_set()
+    {
+        $this->loadMigrationsFrom([
+            '--database' => 'testbench',
+            '--path' => realpath(__DIR__.'/migrations'),
+        ]);
+
+        $user = User::create([
+            'name' => 'James Judd',
+            'email' => 'james.judd@revisionable.test',
+            'date' => '2026-07-30',
+            'password' => \Hash::make('456'),
+        ]);
+
+        // Set custom casts
+        $user->mergeCasts([
+            'date' => 'date::Y-m-d',
+        ]);
+
+        // Create a datetime string that represents the same date in a different timezone
+        $dateTimeInNonUtcTimezone = "2026-07-31T00:00:00+01:00";
 
         $user->update([
             'date' => $dateTimeInNonUtcTimezone

--- a/tests/DateRevisionTest.php
+++ b/tests/DateRevisionTest.php
@@ -3,6 +3,8 @@
 namespace Venturecraft\Revisionable\Tests;
 
 use Carbon\Carbon;
+use Config;
+use Illuminate\Support\Facades\DB;
 use Venturecraft\Revisionable\Tests\Models\User;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -138,6 +140,37 @@ class DateRevisionTest extends TestCase
         // Change date
         $user->update([
             'date' => '2025-12-18 23:59:59',
+        ]);
+
+        // we should have no revisions to the date
+        $this->assertCount(0, $user->revisionHistory);
+    }
+
+    #[Test]
+    public function revision_is_not_stored_when_a_custom_cast_datetime_object_in_a_different_timezone_is_set()
+    {
+        $this->loadMigrationsFrom([
+            '--database' => 'testbench',
+            '--path' => realpath(__DIR__.'/migrations'),
+        ]);
+
+        $user = User::create([
+            'name' => 'James Judd',
+            'email' => 'james.judd@revisionable.test',
+            'date' => '2025-04-01',
+            'password' => \Hash::make('456'),
+        ]);
+
+        // Set custom casts
+        $user->mergeCasts([
+            'date' => 'date::Y-m-d',
+        ]);
+
+        // Create a datetime string that represents the same date in a different timezone
+        $dateTimeInNonUtcTimezone = Carbon::parse('2025-03-31 20:00:00.0', 'America/New_York');
+
+        $user->update([
+            'date' => $dateTimeInNonUtcTimezone
         ]);
 
         // we should have no revisions to the date

--- a/tests/DateRevisionTest.php
+++ b/tests/DateRevisionTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Venturecraft\Revisionable\Tests;
+
+use Carbon\Carbon;
+use Venturecraft\Revisionable\Tests\Models\User;
+use PHPUnit\Framework\Attributes\Test;
+
+class DateRevisionTest extends TestCase
+{
+    #[Test]
+    public function revision_is_stored_when_date_attribute_is_date_string()
+    {
+        $this->loadMigrationsFrom([
+            '--database' => 'testbench',
+            '--path' => realpath(__DIR__.'/migrations'),
+        ]);
+
+        $user = User::create([
+            'name' => 'James Judd',
+            'email' => 'james.judd@revisionable.test',
+            'date' => '2025-12-18',
+            'password' => \Hash::make('456'),
+        ]);
+
+        // Change date
+        $user->update([
+            'date' => '2025-12-19'
+        ]);
+
+        // we should have 1 revision to the date
+        $this->assertCount(1, $user->revisionHistory);
+        $this->assertEquals('2025-12-18', $user->revisionHistory->first()['old_value']);
+    }
+
+
+     #[Test]
+    public function revision_is_stored_when_date_attribute_is_carbon()
+    {
+        $this->loadMigrationsFrom([
+            '--database' => 'testbench',
+            '--path' => realpath(__DIR__.'/migrations'),
+        ]);
+
+        $user = User::create([
+            'name' => 'James Judd',
+            'email' => 'james.judd@revisionable.test',
+            'date' => '2025-12-18',
+            'password' => \Hash::make('456'),
+        ]);
+
+        // Change date
+        $user->update([
+            'date' => Carbon::parse('2025-12-19'),
+        ]);
+
+        // we should have 1 revision to the date
+        $this->assertCount(1, $user->revisionHistory);
+        $this->assertEquals('2025-12-19', $user->revisionHistory->first()['new_value']);
+    }
+
+
+    #[Test]
+    public function revision_is_stored_when_date_attribute_is_date_time_string()
+    {
+        $this->loadMigrationsFrom([
+            '--database' => 'testbench',
+            '--path' => realpath(__DIR__.'/migrations'),
+        ]);
+
+        $user = User::create([
+            'name' => 'James Judd',
+            'email' => 'james.judd@revisionable.test',
+            'date' => '2025-12-18',
+            'password' => \Hash::make('456'),
+        ]);
+
+        // Set casts on date attribute
+        $user->mergeCasts([
+            'date' => 'datetime',
+        ]);
+
+        // Change date
+        $user->update([
+            'date' => '2025-12-19 01:00:00',
+        ]);
+
+        // we should have 1 revision to the date
+        $this->assertCount(1, $user->revisionHistory);
+        $this->assertEquals('2025-12-19', $user->revisionHistory->first()['new_value']);
+    }
+
+    #[Test]
+    public function revision_is_not_stored_when_date_attribute_is_carbon_but_date_is_same()
+    {
+        $this->loadMigrationsFrom([
+            '--database' => 'testbench',
+            '--path' => realpath(__DIR__.'/migrations'),
+        ]);
+
+        $user = User::create([
+            'name' => 'James Judd',
+            'email' => 'james.judd@revisionable.test',
+            'date' => '2025-12-18',
+            'password' => \Hash::make('456'),
+        ]);
+
+        // Change date
+        $user->update([
+            'date' => Carbon::parse('2025-12-18'),
+        ]);
+
+        // we should have no revisions to the date
+        $this->assertCount(0, $user->revisionHistory);
+    }
+
+
+    #[Test]
+    public function revision_is_not_stored_when_date_attribute_is_datetime_string_but_date_is_same()
+    {
+        $this->loadMigrationsFrom([
+            '--database' => 'testbench',
+            '--path' => realpath(__DIR__.'/migrations'),
+        ]);
+
+        $user = User::create([
+            'name' => 'James Judd',
+            'email' => 'james.judd@revisionable.test',
+            'date' => '2025-12-18',
+            'password' => \Hash::make('456'),
+        ]);
+
+        // Set casts on date attribute
+        $user->mergeCasts([
+            'date' => 'date',
+        ]);
+
+        // Change date
+        $user->update([
+            'date' => '2025-12-18 23:59:59',
+        ]);
+
+        // we should have no revisions to the date
+        $this->assertCount(0, $user->revisionHistory);
+    }
+}

--- a/tests/RevisionTest.php
+++ b/tests/RevisionTest.php
@@ -4,41 +4,8 @@ namespace Venturecraft\Revisionable\Tests;
 
 use Venturecraft\Revisionable\Tests\Models\User;
 
-class RevisionTest extends \Orchestra\Testbench\TestCase
+class RevisionTest extends TestCase
 {
-    /**
-     * Setup the test environment.
-     */
-    protected function setUp()
-    {
-        parent::setUp();
-        $this->loadLaravelMigrations(['--database' => 'testing']);
-
-        // call migrations specific to our tests, e.g. to seed the db
-        // the path option should be an absolute path.
-        $this->loadMigrationsFrom([
-            '--database' => 'testing',
-            '--path' => realpath(__DIR__.'/../src/migrations'),
-        ]);
-    }
-
-    /**
-     * Define environment setup.
-     *
-     * @param  \Illuminate\Foundation\Application $app
-     * @return void
-     */
-    protected function getEnvironmentSetUp($app)
-    {
-        // Setup default database to use sqlite :memory:
-        $app['config']->set('database.default', 'testbench');
-        $app['config']->set('database.connections.testbench', array(
-            'driver' => 'sqlite',
-            'database' => ':memory:',
-            'prefix' => '',
-        ));
-    }
-
     /**
      * Test we can interact with the database
      */
@@ -86,7 +53,7 @@ class RevisionTest extends \Orchestra\Testbench\TestCase
     public function testRevisionStoredAdditionalFields()
     {
         $this->loadMigrationsFrom([
-            '--database' => 'testing',
+            '--database' => 'testbench',
             '--path' => realpath(__DIR__.'/migrations'),
         ]);
 
@@ -117,7 +84,7 @@ class RevisionTest extends \Orchestra\Testbench\TestCase
     public function testRevisionSkipsAdditionalFieldsWhenNotAvailable()
     {
         $this->loadMigrationsFrom([
-            '--database' => 'testing',
+            '--database' => 'testbench',
             '--path' => realpath(__DIR__.'/migrations'),
         ]);
 
@@ -147,7 +114,7 @@ class RevisionTest extends \Orchestra\Testbench\TestCase
     public function testRevisionSkipsAdditionalFieldsWhenMisconfigured()
     {
         $this->loadMigrationsFrom([
-            '--database' => 'testing',
+            '--database' => 'testbench',
             '--path' => realpath(__DIR__.'/migrations'),
         ]);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Venturecraft\Revisionable\Tests;
+
+use DB;
+use Illuminate\Support\Facades\Schema;
+use Venturecraft\Revisionable\Tests\Models\User;
+
+class TestCase extends \Orchestra\Testbench\TestCase
+{
+    /**
+     * Setup the test environment.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->loadLaravelMigrations(['--database' => 'testbench']);
+
+        // call migrations specific to our tests, e.g. to seed the db
+        // the path option should be an absolute path.
+        $this->loadMigrationsFrom([
+            '--database' => 'testbench',
+            '--path' => realpath(__DIR__.'/../src/migrations'),
+        ]);
+
+        // Bind mock RevisionRepository Class
+        $this->app->singleton(\App\Repositories\Revision\RevisionRepository::class, function () { 
+            return new class {
+                public function getExtraAttributes(): array { 
+                    return []; 
+                } 
+            }; 
+        });
+    }
+
+    /**
+     * Define environment setup.
+     *
+     * @param  \Illuminate\Foundation\Application $app
+     * @return void
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        // Setup default database to use sqlite :memory:
+        $app['config']->set('database.default', 'testbench');
+        $app['config']->set('database.connections.testbench', array(
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ));
+    }
+}

--- a/tests/migrations/2025_12_18_062330_add_date_field_to_users.php
+++ b/tests/migrations/2025_12_18_062330_add_date_field_to_users.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class AddDateFieldToUsers extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->date('date')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+       Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('date');
+        });
+    }
+}


### PR DESCRIPTION
 - Updated phpunit.xml to work with phpunit 10
 -  Handle changed date attributes which are not formatted as date strings
 - Correctly compare non UTC timezone objects when a property has custom date casting
 - Add tests for date attributes